### PR TITLE
fix-sunburst-bezier-lines

### DIFF
--- a/AgileVisualizationAPressCode-main/01-02-QuickStart.txt
+++ b/AgileVisualizationAPressCode-main/01-02-QuickStart.txt
@@ -67,7 +67,7 @@ RSLineBuilder sunburstBezier
 		yourself);
 	canvas: sb canvas;
 	connectFrom: #superclass.
-sb open
+sb canvas open
 
 -----------------------------
 nodesModel := $a to: $s.


### PR DESCRIPTION
The Sunburst example on chapter 2 does not show the bezier lines connecting the classes and subclasses.